### PR TITLE
Comment out the unnecessary print statement in call_sync

### DIFF
--- a/huobi/connection/impl/restapi_invoker.py
+++ b/huobi/connection/impl/restapi_invoker.py
@@ -54,7 +54,7 @@ def call_sync(request, is_checked=False):
         if is_checked is True:
             return response.text
         dict_data = json.loads(response.text, encoding="utf-8")
-        print("call_sync  === recv data : ", dict_data)
+        # print("call_sync  === recv data : ", dict_data)
         check_response(dict_data)
         return request.json_parser(dict_data)
 


### PR DESCRIPTION
The print statement is unnecessary and should be commented out just like any other print statements in this file.