### PR TITLE
Fix the wrong param name when getting historical candlesticks

### DIFF
--- a/huobi/client/market.py
+++ b/huobi/client/market.py
@@ -33,7 +33,7 @@ class MarketClient(object):
 
         params = {
             "symbol": symbol,
-            "interval": interval,
+            "period": interval,
             "size": size
         }
         from huobi.service.market.get_candlestick import GetCandleStickService


### PR DESCRIPTION
curl "https://api.huobi.pro/market/history/kline?interval=1day&size=2&symbol=btcusdt" always gives me 1min candlesticks regardless of which interval is specified.

the correct param name is 'period', instead of 'interval'.