### PR TITLE
Json encoding deprecated

### DIFF
--- a/huobi/connection/impl/restapi_invoker.py
+++ b/huobi/connection/impl/restapi_invoker.py
@@ -53,14 +53,14 @@ def call_sync(request, is_checked=False):
         response = session.get(request.host + request.url, headers=request.header)
         if is_checked is True:
             return response.text
-        dict_data = json.loads(response.text, encoding="utf-8")
+        dict_data = json.loads(response.text)
         # print("call_sync  === recv data : ", dict_data)
         check_response(dict_data)
         return request.json_parser(dict_data)
 
     elif request.method == "POST":
         response = session.post(request.host + request.url, data=json.dumps(request.post_body), headers=request.header)
-        dict_data = json.loads(response.text, encoding="utf-8")
+        dict_data = json.loads(response.text)
         # print("call_sync  === recv data : ", dict_data)
         check_response(dict_data)
         return request.json_parser(dict_data)
@@ -76,7 +76,7 @@ def call_sync_perforence_test(request, is_checked=False):
         req_cost = response.elapsed.total_seconds()
         if is_checked is True:
             return response.text
-        dict_data = json.loads(response.text, encoding="utf-8")
+        dict_data = json.loads(response.text)
         # print("call_sync  === recv data : ", dict_data)
         check_response(dict_data)
         return request.json_parser(dict_data), req_cost, cost_manual
@@ -87,7 +87,7 @@ def call_sync_perforence_test(request, is_checked=False):
         inner_end_time = time.time()
         cost_manual = round(inner_end_time - inner_start_time, 6)
         req_cost = response.elapsed.total_seconds()
-        dict_data = json.loads(response.text, encoding="utf-8")
+        dict_data = json.loads(response.text)
         # print("call_sync  === recv data : ", dict_data)
         check_response(dict_data)
         return request.json_parser(dict_data), req_cost, cost_manual


### PR DESCRIPTION
`_Changed in version 3.9: The keyword argument encoding has been removed._`

This option has been deprecated since python 3.1